### PR TITLE
Several improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ This component requires a ``OneLogin_Saml`` configuration stored in a php file. 
 ```php
 <?php
 
-$spBaseUrl = Yii::app()->getBaseUrl(true);
+$urlManager = Yii::$app->urlManager;
+$spBaseUrl = $urlManager->getHostInfo() . $urlManager->getBaseUrl();
 
 return [
     'sp' => [
@@ -81,7 +82,17 @@ This extension provides 4 actions:
     ```php
     <?php
 
+    namespace app\controllers;
+
+    use Yii;
+    use yii\web\Controller;
+    use yii\helpers\Url;
+
+
     class SamlController extends Controller {
+
+        // Remove CSRF protection
+        public $enableCsrfValidation = false;
 
         public function actions() {
             return [
@@ -103,10 +114,21 @@ This extension provides 4 actions:
     ```php
     <?php
 
+    namespace app\controllers;
+
+    use Yii;
+    use yii\web\Controller;
+    use yii\helpers\Url;
+
+
     class SamlController extends Controller {
+
+        // Remove CSRF protection
+        public $enableCsrfValidation = false;
 
         public function actions() {
             return [
+                ...
                 'acs' => [
                     'class' => 'asasmoyo\yii2saml\actions\AcsAction',
                     'successCallback' => [$this, 'callback'],
@@ -121,7 +143,6 @@ This extension provides 4 actions:
         public function callback($attributes) {
             // do something
         }
-
     }
     ```
 
@@ -134,17 +155,14 @@ This extension provides 4 actions:
     ```php
     <?php
 
-    class SamlController extends Controller {
-
         public function actions() {
             return [
+                ...
                 'metadata' => [
                     'class' => 'asasmoyo\yii2saml\actions\MetadataAction'
                 ]
             ];
         }
-
-    }
     ```
 
 4. LogoutAction
@@ -154,18 +172,15 @@ This extension provides 4 actions:
     ```php
     <?php
 
-    class SamlController extends Controller {
-
         public function actions() {
             return [
+                ...
                 'logout' => [
                     'class' => 'asasmoyo\yii2saml\actions\LogoutAction',
                     'returnTo' => Url::to('site/bye'),
                 ]
             ];
         }
-
-    }
     ```
 
 5. SlsAction
@@ -175,17 +190,17 @@ This extension provides 4 actions:
     ```php
     <?php
 
-    class SamlController extends Controller {
-
         public function actions() {
+            ...
+
             return [
+                ...
                 'sls' => [
                     'class' => 'asasmoyo\yii2saml\actions\SlsAction',
                     'successUrl' => Url::to('site/bye'),
                 ]
             ]
         }
-    }
     ```
 
 LICENCE

--- a/README.md
+++ b/README.md
@@ -43,15 +43,16 @@ This component requires a ``OneLogin_Saml`` configuration stored in a php file. 
 ```php
 <?php
 
-$spBaseUrl = 'https://yoursite.com';
+$spBaseUrl = Yii::app()->getBaseUrl(true);
+
 return [
     'sp' => [
-        'entityId' => $spBaseUrl.'/demo1/metadata.php',
+        'entityId' => $spBaseUrl.'/saml/metadata',
         'assertionConsumerService' => [
-            'url' => $spBaseUrl.'/demo1/index.php?acs',
+            'url' => $spBaseUrl.'/saml/acs',
         ],
         'singleLogoutService' => [
-            'url' => $spBaseUrl.'/demo1/index.php?sls',
+            'url' => $spBaseUrl.'/saml/logout',
         ],
         'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
     ],
@@ -63,7 +64,7 @@ return [
         'singleLogoutService' => [
             'url' => 'https://idp.com/sls',
         ],
-        'x509cert' => 'someweirdstrings',
+        'x509cert' => '<x509cert string>',
     ],
 ];
 ```

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ return [
             'url' => $spBaseUrl.'/saml/acs',
         ],
         'singleLogoutService' => [
-            'url' => $spBaseUrl.'/saml/logout',
+            'url' => $spBaseUrl.'/saml/sls',
         ],
         'NameIDFormat' => 'urn:oasis:names:tc:SAML:1.1:nameid-format:unspecified',
     ],
@@ -125,7 +125,7 @@ This extension provides 4 actions:
     }
     ```
 
-    **NOTE: Make sure to register the acs action's url to ``AssertionConsumerService`` in Identity Provider.**
+    **NOTE: Make sure to register the acs action's url to ``AssertionConsumerService`` and the sls actions's url to ``SingleLogoutService`` (if supported) in the Identity Provider.**
 
 3. MetadataAction
 
@@ -165,6 +165,26 @@ This extension provides 4 actions:
             ];
         }
 
+    }
+    ```
+
+5. SlsAction
+
+    This action will process saml logout request/response sent by Identity Provider. To use this action just register this action to you controllers's actions.
+
+    ```php
+    <?php
+
+    class SamlController extends Controller {
+
+        public function actions() {
+            return [
+                'sls' => [
+                    'class' => 'asasmoyo\yii2saml\actions\SlsAction',
+                    'successUrl' => Url::to('site/bye'),
+                ]
+            ]
+        }
     }
     ```
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,16 @@ This extension provides 4 actions:
         }
     ```
 
+Usage
+-----
+
+If the SAMLResponse is rejected, add to the SAML settings the parameter
+``` 
+'debug' => true,
+```
+and the reason will be prompted.
+
+
 LICENCE
 -------
 

--- a/src/Saml.php
+++ b/src/Saml.php
@@ -78,10 +78,10 @@ class Saml extends Object
      */
     public function getMetadata()
     {
-        $oneLoginSetting = new \OneLogin_Saml2_Settings($this->config, true);
-        $metadata = $oneLoginSetting->getSPMetadata();
+        $samlSettings = new \OneLogin_Saml2_Settings($this->config, true);
+        $metadata = $samlSettings->getSPMetadata();
 
-        $errors = $oneLoginSetting->validateMetadata($metadata);
+        $errors = $samlSettings->validateMetadata($metadata);
         if (!empty($errors)) {
             throw new \Exception('Invalid Metadata Service Provider');
         }
@@ -110,4 +110,20 @@ class Saml extends Object
         return $this->instance->getErrors();
     }
 
+    /**
+     * Call the getLastErrorReason method on OneLogin_Saml2_Auth.
+     */
+    public function getLastErrorReason()
+    {
+        return $this->instance->getLastErrorReason();
+    }
+
+    /**
+     * Check if debug is enabled on OneLogin_Saml2_Auth.
+     */
+    public function isDebugActive()
+    {
+        $samlSettings = $this->instance->getSettings();
+        return $samlSettings->isDebugActive();
+    }
 }

--- a/src/Saml.php
+++ b/src/Saml.php
@@ -97,6 +97,11 @@ class Saml extends Object
         $this->instance->processResponse();
     }
 
+    public function processSLO()
+    {
+        $this->instance->processSLO();   
+    }
+
     /**
      * Call the getErrors method on OneLogin_Saml2_Auth.
      */

--- a/src/actions/AcsAction.php
+++ b/src/actions/AcsAction.php
@@ -14,6 +14,13 @@ class AcsAction extends BaseAction
 {
 
     /**
+     * This array contains the mapping between Identity Provider user attribute names and Yii2 user attribute names
+     * You may define at least the mapping for the username
+     * @var array
+     */
+    public $attributeMapping = array();
+
+    /**
      * This callable will be called when a login process is succesfull. The attributes sent from Identity Provider will be passed to this method.
      * @var callable
      */
@@ -37,7 +44,13 @@ class AcsAction extends BaseAction
 
         $errors = $this->samlInstance->getErrors();
         if (!empty($errors)) {
-            $message = 'Saml response error: ' . var_export($errors, true);
+            $message = 'Saml response error: ' . implode(",", $errors);
+            if ($this->samlInstance->isDebugActive()) {
+                $reason = $this->samlInstance->getLastErrorReason();
+                if (!empty($reason)) {
+                    $message .= "\n".$reason;
+                }
+            }
             throw new Exception($message);
         }
 

--- a/src/actions/LogoutAction.php
+++ b/src/actions/LogoutAction.php
@@ -19,14 +19,7 @@ class LogoutAction extends BaseAction
      */
     public function run()
     {
-        // Check wether SAMLResponse is present. If it is, we process the response and redirect the user to returnTo.
-        $response = \Yii::$app->request->post('SAMLResponse');
-        if ($response) {
-            $this->samlInstance->processResponse();
-            return \Yii::$app->response->redirect($this->returnTo);
-        }
-
-        // if it isn't, logout the user on Yii 2 and Identity Provider.
+        // logout the user on Yii 2 and Identity Provider.
         \Yii::$app->user->logout();
         $this->samlInstance->logout($this->returnTo);
     }

--- a/src/actions/SlsAction.php
+++ b/src/actions/SlsAction.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace asasmoyo\yii2saml\actions;
+
+use yii\base\Exception;
+use yii\base\InvalidConfigException;
+use yii\web\Response;
+
+
+/**
+ * This class handles saml logout request and response.
+ */
+class SlsAction extends BaseAction
+{
+    /**
+     * After succesfull logout process user will be redirected to this url.
+     * @var string
+     */
+    public $successUrl;
+
+    /**
+     * It handles sls logout request/response from Identity Provider. It will check whether is valid or not. If it isn't, an Exception will be thrown. If is valid, the successCallback will be called. You can use the callback to create user from attributes sent by Identity Provider or do something else. After that, user will be redirected to successUrl.     * @return $this|mixed
+     * @throws Exception
+     * @throws InvalidConfigException
+     */
+    public function run()
+    {
+        // Check wether SAMLRequest/SAMLResponse is present. If it is, we process the logout request/response and redirect the user to returnTo.
+        $request = \Yii::$app->request->get('SAMLRequest');
+        $response = \Yii::$app->request->get('SAMLResponse');
+        if ($request || $response) {
+            $this->samlInstance->processSLO();
+            return \Yii::$app->response->redirect($this->returnTo);
+        }
+    }
+}

--- a/src/actions/SlsAction.php
+++ b/src/actions/SlsAction.php
@@ -12,6 +12,7 @@ use yii\web\Response;
  */
 class SlsAction extends BaseAction
 {
+
     /**
      * After succesfull logout process user will be redirected to this url.
      * @var string
@@ -25,12 +26,19 @@ class SlsAction extends BaseAction
      */
     public function run()
     {
-        // Check wether SAMLRequest/SAMLResponse is present. If it is, we process the logout request/response and redirect the user to returnTo.
-        $request = \Yii::$app->request->get('SAMLRequest');
-        $response = \Yii::$app->request->get('SAMLResponse');
-        if ($request || $response) {
-            $this->samlInstance->processSLO();
-            return \Yii::$app->response->redirect($this->returnTo);
+        $this->samlInstance->processSLO();
+
+        $errors = $this->samlInstance->getErrors();
+        if (!empty($errors)) {
+            $message = 'Logout error: ' . implode(",", $errors);
+            if ($this->samlInstance->isDebugActive()) {
+                $reason = $this->samlInstance->getLastErrorReason();
+                if (!empty($reason)) {
+                    $message .= "\n".$reason;
+                }
+            }
+            throw new Exception($message);
         }
+        return \Yii::$app->response->redirect($this->returnTo);
     }
 }

--- a/src/actions/SlsAction.php
+++ b/src/actions/SlsAction.php
@@ -20,7 +20,7 @@ class SlsAction extends BaseAction
     public $successUrl;
 
     /**
-     * It handles sls logout request/response from Identity Provider. It will check whether is valid or not. If it isn't, an Exception will be thrown. If is valid, the successCallback will be called. You can use the callback to create user from attributes sent by Identity Provider or do something else. After that, user will be redirected to successUrl.     * @return $this|mixed
+     * It handles sls logout request/response from Identity Provider. It will check whether is valid or not. If it isn't, an Exception will be thrown. If is valid,  user will be redirected to successUrl.     * @return $this|mixed
      * @throws Exception
      * @throws InvalidConfigException
      */
@@ -39,6 +39,6 @@ class SlsAction extends BaseAction
             }
             throw new Exception($message);
         }
-        return \Yii::$app->response->redirect($this->returnTo);
+        return \Yii::$app->response->redirect($this->successUrl);
     }
 }


### PR DESCRIPTION
**SLO**
php-saml toolkit supports SLO (IdP-initiated / SP/initiaited) on the HTTP-Redirect binding, but the code present on yii2-saml check only for a SAMLResponse on the HTTP-POST binding.

**Split SLO and Logout**
In the SAML integrations I used to split those actions, so I spitted them here.

**Readme**
I added the right paths instead of the old ones that refered php-saml demo example
 
**Ability to debug**
Now if 'debug' is enabled on SAML settings the reason for rejecting SAML messages will be showed.