### PR TITLE
Compatibility with PHP 7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "yiisoft/yii2": "*",
+        "yiisoft/yii2": ">=2.0.13",
         "onelogin/php-saml": "~2.13.0"
     },
     "require-dev": {

--- a/src/Saml.php
+++ b/src/Saml.php
@@ -3,12 +3,12 @@
 namespace asasmoyo\yii2saml;
 
 use Yii;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * This class wraps OneLogin_Saml2_Auth class by creating an instance of that class using configurations specified in configFileName variable inside @app/config folder.
  */
-class Saml extends Object
+class Saml extends BaseObject
 {
 
     /**


### PR DESCRIPTION
In PHP 7.2 `Object` is a reserved word.

See
https://secure.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.object-reserved-word
https://github.com/yiisoft/yii2/issues/7936