### PR TITLE
Syntax error in  README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ $config = [
                     ],
                     'x509cert' => '<x509cert string>',
                 ],
-            ];
+            ],
         ]
     ],
 


### PR DESCRIPTION
Semicolon replaced by a comma.